### PR TITLE
spec: Migrate to Node.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lobsters-example.js
+++ b/lobsters-example.js
@@ -1,7 +1,8 @@
 // This is an example of how to use the Lobsters spec to deploy
 // Lobsters to a single Amazon instance.
 
-var lobsters = require("github.com/quilt/lobsters")
+const {createDeployment, Machine} = require("@quilt/quilt");
+var lobsters = require("./lobsters.js")
 
 var deployment = createDeployment();
 // To use this example, change this to your RSA public key.

--- a/lobsters.js
+++ b/lobsters.js
@@ -1,6 +1,8 @@
 // Contains functionality to deploy Lobsters. See lobsters-example.js for
 // an example of how to use this file.
 
+const {Container, Service, publicInternet} = require("@quilt/quilt");
+
 exports.Deploy = function(deployment, sqlRootPassword) {
     // Create a container for mysql.
     var sqlContainer = new Container("mysql:5.6.32");

--- a/package.json
+++ b/package.json
@@ -1,3 +1,9 @@
 {
-    "main": "./lobsters.js"
+  "name": "@quilt/lobsters",
+  "version": "0.0.1",
+  "main": "./lobsters.js",
+  "license": "MIT",
+  "dependencies": {
+    "@quilt/quilt": "quilt/quilt"
+  }
 }


### PR DESCRIPTION
`quilt run` now runs within the Node.js runtime. This is a breaking
change, requiring a number of changes to our specs.